### PR TITLE
Allow multiple tests in a row (fix issues/7)

### DIFF
--- a/Libight_iOS/Libight_iOS/ViewController.mm
+++ b/Libight_iOS/Libight_iOS/ViewController.mm
@@ -59,12 +59,10 @@
 }
 
 - (IBAction) runTests:(id)sender {
-    if (self.selectedMeasurement != nil){
+    if (self.selectedMeasurement != nil) {
         [self.selectedMeasurement run];
         [self.manager.runningNetworkMeasurements addObject:self.selectedMeasurement];
         [self.tableView reloadData];
-        self.selectedMeasurement = nil;
-        [self unselectAll];
     }
 }
 


### PR DESCRIPTION
This should fix measurement-kit/measurement-kit-app-ios#7 and allow to submit two tests by clicking twice on RUN. This is simple enough to qualify as an hotfix. I tested this code on top of #14 and then backported it on top of master and tested it again on top of master.