### PR TITLE
Autoreload table when test is over

### DIFF
--- a/Libight_iOS/Libight_iOS/Base.lproj/Storyboard_iPad.storyboard
+++ b/Libight_iOS/Libight_iOS/Base.lproj/Storyboard_iPad.storyboard
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="7531" systemVersion="14D131" targetRuntime="iOS.CocoaTouch.iPad" propertyAccessControl="none" useAutolayout="YES" initialViewController="2TR-Dd-UZ1">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="7706" systemVersion="14E46" targetRuntime="iOS.CocoaTouch.iPad" propertyAccessControl="none" useAutolayout="YES" initialViewController="2TR-Dd-UZ1">
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="7520"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="7703"/>
     </dependencies>
     <customFonts key="customFonts">
         <mutableArray key="Inconsolata.otf">
@@ -144,7 +144,7 @@
                                                 </label>
                                                 <progressView opaque="NO" tag="2" contentMode="scaleToFill" verticalHuggingPriority="750" fixedFrame="YES" progress="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="ENX-Q8-Io2">
                                                     <rect key="frame" x="325" y="24" width="384" height="2"/>
-                                                    <color key="progressTintColor" red="0.59607843137254901" green="0.84313725490196079" blue="0.81960784313725488" alpha="1" colorSpace="calibratedRGB"/>
+                                                    <color key="progressTintColor" red="0.19215686269999999" green="0.43921568630000002" blue="0.70980392160000005" alpha="1" colorSpace="calibratedRGB"/>
                                                 </progressView>
                                                 <button opaque="NO" tag="3" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="79e-Nh-JG2">
                                                     <rect key="frame" x="717" y="12" width="43" height="25"/>

--- a/Libight_iOS/Libight_iOS/Base.lproj/Storyboard_iPhone.storyboard
+++ b/Libight_iOS/Libight_iOS/Base.lproj/Storyboard_iPhone.storyboard
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="7531" systemVersion="14D131" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" initialViewController="Jib-VG-5vz">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="7706" systemVersion="14E46" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" initialViewController="Jib-VG-5vz">
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="7520"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="7703"/>
     </dependencies>
     <customFonts key="customFonts">
         <mutableArray key="Inconsolata.otf">
@@ -147,7 +147,7 @@
                                                 </label>
                                                 <progressView opaque="NO" tag="2" contentMode="scaleToFill" verticalHuggingPriority="750" fixedFrame="YES" progress="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="hKV-az-L21">
                                                     <rect key="frame" x="8" y="40" width="304" height="2"/>
-                                                    <color key="progressTintColor" red="0.59607843140000005" green="0.84313725490000002" blue="0.81960784310000001" alpha="1" colorSpace="calibratedRGB"/>
+                                                    <color key="progressTintColor" red="0.19215686269999999" green="0.43921568630000002" blue="0.70980392160000005" alpha="1" colorSpace="calibratedRGB"/>
                                                 </progressView>
                                                 <button opaque="NO" tag="3" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="o7e-rV-RDq">
                                                     <rect key="frame" x="269" y="8" width="43" height="25"/>

--- a/Libight_iOS/Libight_iOS/NetworkMeasurement.h
+++ b/Libight_iOS/Libight_iOS/NetworkMeasurement.h
@@ -20,6 +20,7 @@
 @property NSString *name;
 @property NSNumber *test_id;
 @property NSString *status;
+@property BOOL finished;
 @property NSMutableArray *logLines;
 @property ight::common::settings::Settings options;
 @property NetworkManager *manager;

--- a/Libight_iOS/Libight_iOS/NetworkMeasurement.mm
+++ b/Libight_iOS/Libight_iOS/NetworkMeasurement.mm
@@ -34,6 +34,7 @@ static ight::common::async::Async& get_async() {
 -(id) init {
     self = [super init];
     self.logLines = [[NSMutableArray alloc] init];
+    self.finished = FALSE;
     return self;
 }
 
@@ -67,7 +68,12 @@ static ight::common::async::Async& get_async() {
         [self.logLines addObject:[NSString stringWithUTF8String:s]];
         NSLog(@"%s", s);
     });
-    async.run_test(test);
+    async.run_test(test, [self](ight::common::async::SharedPointer<
+                                ight::common::net_test::NetTest> t) {
+        NSLog(@"dns_injection testEnded");
+        self.finished = TRUE;
+        [[NSNotificationCenter defaultCenter] postNotificationName:@"refreshTable" object:nil];
+    });
 }
 
 
@@ -96,7 +102,12 @@ static ight::common::async::Async& get_async() {
         [self.logLines addObject:[NSString stringWithUTF8String:s]];
         NSLog(@"%s", s);
     });
-    async.run_test(test);
+    async.run_test(test, [self](ight::common::async::SharedPointer<
+                                ight::common::net_test::NetTest> t) {
+        NSLog(@"http_invalid_request_line testEnded");
+        self.finished = TRUE;
+        [[NSNotificationCenter defaultCenter] postNotificationName:@"refreshTable" object:nil];
+    });
 }
 
 @end
@@ -124,7 +135,12 @@ static ight::common::async::Async& get_async() {
         [self.logLines addObject:[NSString stringWithUTF8String:s]];
         NSLog(@"%s", s);
     });
-    async.run_test(test);
+    async.run_test(test, [self](ight::common::async::SharedPointer<
+                                ight::common::net_test::NetTest> t) {
+        NSLog(@"tcp_connect testEnded");
+        self.finished = TRUE;
+        [[NSNotificationCenter defaultCenter] postNotificationName:@"refreshTable" object:nil];
+    });
 }
 
 @end

--- a/Libight_iOS/Libight_iOS/ViewController.mm
+++ b/Libight_iOS/Libight_iOS/ViewController.mm
@@ -27,7 +27,7 @@
     self.manager = [[NetworkManager alloc] init];
     self.manager.running = false;
     self.manager.runningNetworkMeasurements = [[NSMutableArray alloc] init];
-
+    [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(refreshTable) name:@"refreshTable" object:nil];
     [self setLabels];
 }
 
@@ -40,6 +40,10 @@
     
     HTTPInvalidRequestLine *http_invalid_request_lineMeasurement = [[HTTPInvalidRequestLine alloc] init];
     [self.availableNetworkMeasurements addObject:http_invalid_request_lineMeasurement];
+}
+
+-(void)refreshTable{
+    [self.tableView reloadData];
 }
 
 - (void) setLabels {
@@ -86,7 +90,8 @@
     NetworkMeasurement *current = [self.manager.runningNetworkMeasurements objectAtIndex:indexPath.row];
     [title setText:NSLocalizedString(current.name, nil)];
     //[title setText:NSLocalizedString(@"dns_injection", nil)];
-    [bar setProgress:0.4 animated:YES];
+    if (current.finished) [bar setProgress:1.0 animated:YES];
+    else [bar setProgress:0.2 animated:YES];
     return cell;
 }
 


### PR DESCRIPTION
This pull request contains @lorenzoPrimi's patch to autoreload table when a test is over, plus another commit to sync up with measurement-kit-build-ios such that SDKVERSION="8.4" is used.